### PR TITLE
Add user-specific sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ This project provides a simple async interface to interact with an Ollama model 
 python run.py
 ```
 
-The script will ask the model to compute an arithmetic expression and print the answer. Conversations are automatically persisted to `chat.db`.
+The script will ask the model to compute an arithmetic expression and print the answer. Conversations are automatically persisted to `chat.db` and are now associated with a user and session.

--- a/run.py
+++ b/run.py
@@ -6,7 +6,7 @@ from src.chat import ChatSession
 
 
 async def _main() -> None:
-    async with ChatSession() as chat:
+    async with ChatSession(user="demo_user") as chat:
         answer = await chat.chat("What is 10 + 23?")
         print("\n>>>", answer)
 

--- a/src/db.py
+++ b/src/db.py
@@ -23,8 +23,14 @@ class BaseModel(Model):
         database = _db
 
 
+class User(BaseModel):
+    id = AutoField()
+    username = CharField(unique=True)
+
+
 class Conversation(BaseModel):
     id = AutoField()
+    user = ForeignKeyField(User, backref="conversations")
     started_at = DateTimeField(default=datetime.utcnow)
 
 
@@ -36,11 +42,11 @@ class Message(BaseModel):
     created_at = DateTimeField(default=datetime.utcnow)
 
 
-__all__ = ["_db", "Conversation", "Message"]
+__all__ = ["_db", "User", "Conversation", "Message"]
 
 
 def init_db() -> None:
     """Initialise the database and create tables if they do not exist."""
     if _db.is_closed():
         _db.connect()
-    _db.create_tables([Conversation, Message])
+    _db.create_tables([User, Conversation, Message])


### PR DESCRIPTION
## Summary
- add `User` table to track conversations by user
- associate chat sessions with a user in `ChatSession`
- adjust example usage to specify a user

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683bb35b8c9c83219dde7d1ae2064eb4