### PR TITLE
Implement configurable num_ctx option

### DIFF
--- a/src/chat.py
+++ b/src/chat.py
@@ -5,7 +5,7 @@ import json
 
 from ollama import AsyncClient, ChatResponse, Message
 
-from .config import MAX_TOOL_CALL_DEPTH, MODEL_NAME, OLLAMA_HOST
+from .config import MAX_TOOL_CALL_DEPTH, MODEL_NAME, NUM_CTX, OLLAMA_HOST
 from .db import Conversation, Message as DBMessage, User, _db, init_db
 from .log import get_logger
 from .schema import Msg
@@ -78,6 +78,7 @@ class ChatSession:
             messages=messages,
             think=think,
             tools=[add_two_numbers, execute_python],
+            options={"num_ctx": NUM_CTX},
         )
 
     async def _handle_tool_calls(

--- a/src/config.py
+++ b/src/config.py
@@ -6,3 +6,4 @@ from typing import Final
 MODEL_NAME: Final[str] = os.getenv("OLLAMA_MODEL", "qwen3")
 OLLAMA_HOST: Final[str] = os.getenv("OLLAMA_HOST", "http://localhost:11434")
 MAX_TOOL_CALL_DEPTH: Final[int] = 5
+NUM_CTX: Final[int] = int(os.getenv("OLLAMA_NUM_CTX", "4096"))


### PR DESCRIPTION
## Summary
- add `NUM_CTX` constant with environment variable support
- pass `num_ctx` option when making chat requests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python run.py` *(fails: ModuleNotFoundError: No module named 'ollama')*

------
https://chatgpt.com/codex/tasks/task_e_683c6c7f04a48321bc0c6f26639b68d7