### PR TITLE
Remove add_two_numbers tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 This project provides a simple async interface to interact with an Ollama model
 and demonstrates basic tool usage. Chat histories are stored in a local SQLite
 database using Peewee. Histories are persisted per user and session so
-conversations can be resumed with context. Two example tools are included:
+conversations can be resumed with context. One example tool is included:
 
-* **add_two_numbers** – Adds two integers.
 * **execute_python** – Executes Python code in a sandbox with selected built-ins
   and allows importing safe modules like ``math``. The result is returned from a
   ``result`` variable or captured output.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 from .chat import ChatSession
-from .tools import add_two_numbers, execute_python
+from .tools import execute_python
 
-__all__ = ["ChatSession", "add_two_numbers", "execute_python"]
+__all__ = ["ChatSession", "execute_python"]

--- a/src/chat.py
+++ b/src/chat.py
@@ -15,7 +15,7 @@ from .config import (
 from .db import Conversation, Message as DBMessage, User, _db, init_db
 from .log import get_logger
 from .schema import Msg
-from .tools import add_two_numbers, execute_python
+from .tools import execute_python
 
 _LOG = get_logger(__name__)
 
@@ -93,7 +93,7 @@ class ChatSession:
             self._model,
             messages=messages,
             think=think,
-            tools=[add_two_numbers, execute_python],
+            tools=[execute_python],
             options={"num_ctx": NUM_CTX},
         )
 
@@ -108,9 +108,7 @@ class ChatSession:
             return response
 
         for call in response.message.tool_calls:
-            if call.function.name == "add_two_numbers":
-                result = add_two_numbers(**call.function.arguments)
-            elif call.function.name == "execute_python":
+            if call.function.name == "execute_python":
                 result = execute_python(**call.function.arguments)
             else:
                 continue

--- a/src/tools.py
+++ b/src/tools.py
@@ -1,19 +1,6 @@
 from __future__ import annotations
 
-__all__ = ["add_two_numbers", "execute_python"]
-
-
-def add_two_numbers(a: int, b: int) -> int:  # noqa: D401
-    """Add two numbers together.
-
-    Args:
-        a (int): First number to add.
-        b (int): Second number to add.
-
-    Returns:
-        int: The sum of the two numbers.
-    """
-    return a + b
+__all__ = ["execute_python"]
 
 
 def execute_python(code: str) -> str:


### PR DESCRIPTION
## Summary
- drop the `add_two_numbers` utility
- update module exports and remove related references
- keep only the `execute_python` tool
- revise documentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683c720754f08321816c6f469e4c87b4